### PR TITLE
Fix example file crash.

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -38,7 +38,7 @@ fn runcmd(cmd: Vec<String>, exit: &mut bool) {
 }
 
 fn autocomplete(cli: &mut Cli, cmd: Vec<String>) -> eyre::Result<()> {
-    let cmdlist = vec![
+    let mut cmdlist = vec![
         String::from("hello"),
         String::from("upper"),
         String::from("exit"),
@@ -46,6 +46,7 @@ fn autocomplete(cli: &mut Cli, cmd: Vec<String>) -> eyre::Result<()> {
     ];
 
     if cmd.len() == 1 {
+        cmdlist.retain(|x| x.starts_with(&cmd[0]));
         // autocomplete command
         cli.autocomplete(&cmdlist)?;
     } else if cmd.len() > 1 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,13 @@ impl Cli {
         }
     }
 
-    /** Auto-complete the current command with the provided list of possible words */
+    /**
+     * Auto-complete the current command with the provided list of possible words
+     *
+     * <div class="warning">The word list should only contains possible words for the current
+     * input. This function does not filter out the word list, and expect all words in the list to
+     * start with current input.</div>
+     */
     pub fn autocomplete(&mut self, words: &Vec<String>) -> Result<()> {
         if words.is_empty() {
             // Nothing to do


### PR DESCRIPTION
The example file calls Cli::autocomplete with the full list of words. While this works when the input is empty, the code crash if some characters were added.

This fix that issue by filtering the word list before calling Cli::autocomplete.
This behavior was also added to the documentation for autocomplete function.