### PR TITLE
Ctrl+D support

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -10,6 +10,7 @@ async fn main() -> eyre::Result<()> {
         match action {
             Action::Command(cmd) => runcmd(cmd, &mut exit),
             Action::AutoComplete(cmd) => autocomplete(&mut cli, cmd)?,
+            Action::NoAction => exit = true,
         };
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ pub enum Action {
     Command(Vec<String>),
     /** User demand to auto-complete the following command (Command Name + Arguments). */
     AutoComplete(Vec<String>),
+    /** getaction stopped without any actions to report (e.g. EOT was received, on an empty line). */
+    NoAction,
 }
 
 /** Human-readable ANSI Escape Sequences */
@@ -302,6 +304,11 @@ impl Cli {
             match c {
                 0x01 | 0x02 => {
                     self.cursor_reset()?;
+                }
+                0x04 => {
+                    if self.cmd.len() == 0 {
+                        return Ok(Action::NoAction)
+                    }
                 }
                 0x1B => {
                     // ESC (escap)


### PR DESCRIPTION
When hitting ctrl+d, tokiocli get action receive 0x04 (EOT). This caused an issue because that character was then added to the command, messing with autocompletion and command execution.
On top of that, the usual behavior on a ctrl+d is usually to close the program if the line is empty.

To allow for applications to decide what to do with the ctrl+d, I've added a NoAction value to getaction return, only when EOT is read while the cmd is empty.
If EOT is read while cmd is non-empty, it's ignored so not to mess with autocompletion.